### PR TITLE
feature: added datadog integration for send metrics

### DIFF
--- a/.idea/api-to-dataframe.iml
+++ b/.idea/api-to-dataframe.iml
@@ -5,7 +5,7 @@
       <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
       <excludeFolder url="file://$MODULE_DIR$/.venv" />
     </content>
-    <orderEntry type="jdk" jdkName="Poetry (api-to-dataframe) (2)" jdkType="Python SDK" />
+    <orderEntry type="jdk" jdkName="Python 3.11 virtualenv at ~/Library/Caches/pypoetry/virtualenvs/api-to-dataframe-N1kUY9wS-py3.11" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
   <component name="TestRunnerService">

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -3,5 +3,5 @@
   <component name="Black">
     <option name="sdkName" value="Python 3.9 (api-to-dataframe)" />
   </component>
-  <component name="ProjectRootManager" version="2" project-jdk-name="Poetry (api-to-dataframe) (2)" project-jdk-type="Python SDK" />
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.11 virtualenv at ~/Library/Caches/pypoetry/virtualenvs/api-to-dataframe-N1kUY9wS-py3.11" project-jdk-type="Python SDK" />
 </project>

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,18 +5,18 @@ repos:
       - id: check-yaml
       - id: trailing-whitespace
 
-  - repo: local
-    hooks:
-      - id: pylint
-        name: pylint
-        entry: pylint
-        language: system
-        types: [python]
-        args:
-          [
-            "-rn", # Only display messages
-            "--disable=C0114,C0115,C0116, R0903",
-          ]
+  # - repo: local
+  #   hooks:
+  #     - id: pylint
+  #       name: pylint
+  #       entry: pylint
+  #       language: system
+  #       types: [python]
+  #       args:
+  #         [
+  #           "-rn", # Only display messages
+  #           "--disable=C0114,C0115,C0116, R0903",
+  #         ]
 
 #  - repo: local
 #    hooks:

--- a/poetry.lock
+++ b/poetry.lock
@@ -285,6 +285,20 @@ files = [
 toml = ["tomli"]
 
 [[package]]
+name = "datadog"
+version = "0.50.2"
+description = "The Datadog Python library"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
+files = [
+    {file = "datadog-0.50.2-py2.py3-none-any.whl", hash = "sha256:f3297858564b624efbd9ce43e4ea1c2c21e1f0477ab6d446060b536a1d9e431e"},
+    {file = "datadog-0.50.2.tar.gz", hash = "sha256:17725774bf2bb0a48f1d096d92707492c187f24ae08960af0b0c2fa97958fd51"},
+]
+
+[package.dependencies]
+requests = ">=2.6.0"
+
+[[package]]
 name = "dill"
 version = "0.3.9"
 description = "serialize all of Python"
@@ -668,8 +682,8 @@ files = [
 [package.dependencies]
 numpy = [
     {version = ">=1.22.4", markers = "python_version < \"3.11\""},
-    {version = ">=1.23.2", markers = "python_version == \"3.11\""},
     {version = ">=1.26.0", markers = "python_version >= \"3.12\""},
+    {version = ">=1.23.2", markers = "python_version == \"3.11\""},
 ]
 python-dateutil = ">=2.8.2"
 pytz = ">=2020.1"
@@ -777,8 +791,8 @@ astroid = ">=3.3.5,<=3.4.0-dev0"
 colorama = {version = ">=0.4.5", markers = "sys_platform == \"win32\""}
 dill = [
     {version = ">=0.2", markers = "python_version < \"3.11\""},
-    {version = ">=0.3.6", markers = "python_version >= \"3.11\" and python_version < \"3.12\""},
     {version = ">=0.3.7", markers = "python_version >= \"3.12\""},
+    {version = ">=0.3.6", markers = "python_version >= \"3.11\" and python_version < \"3.12\""},
 ]
 isort = ">=4.2.5,<5.13.0 || >5.13.0,<6"
 mccabe = ">=0.6,<0.8"
@@ -1045,4 +1059,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "ac39d671b1de63ed2eaf0c862168197e8bf9b639a134d1c0118f1535edb90d35"
+content-hash = "a16d4407bb71066353cd3fc30169df7cdfb1bd786828ad398af082f2523a890a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "api-to-dataframe"
-version = "1.3.11"
+version = "1.3.12"
 description = "A package to convert API responses to pandas dataframe"
 authors = ["IvanildoBarauna <ivanildo.jnr@outlook.com>"]
 readme = "README.md"
@@ -27,6 +27,7 @@ python = "^3.9"
 pandas = "^2.2.3"
 requests = "^2.32.3"
 logging = "^0.4.9.6"
+datadog = "^0.50.2"
 
 [tool.poetry.group.dev.dependencies]
 poetry-dynamic-versioning = "^1.3.0"

--- a/src/api_to_dataframe/utils/metrics.py
+++ b/src/api_to_dataframe/utils/metrics.py
@@ -1,0 +1,19 @@
+from datadog import initialize, statsd
+
+
+class MetricsClient:
+    def __init__(self) -> None:
+        self.options = options = {
+            "statsd_host": "node-metrics-ba28.ivanildobarauna.dev",
+            "statsd_port": 8125,
+        }
+        self.client = initialize(**options)
+        self.application_name = "api-to-dataframe"
+
+    def increment(
+        self, action: str, tags: list[str] = ["env:production"], value: float = 1.0
+    ):
+
+        tags.append(f"action:{action}")
+
+        statsd.increment(metric=self.application_name, tags=tags, value=value)


### PR DESCRIPTION
This pull request includes several significant changes to the `api-to-dataframe` project, focusing on updating dependencies, integrating metrics tracking, and configuring the development environment.

Dependency and configuration updates:

* Updated the `pyproject.toml` version from `1.3.11` to `1.3.12` and added `datadog` as a dependency. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R30)
* Updated the Python SDK references in `.idea/api-to-dataframe.iml` and `.idea/misc.xml` to use Python 3.11 virtual environment. [[1]](diffhunk://#diff-b2cfe8441d5d2d2d368441f16cd3dda1929f3180692c74aa93cd1f9546056f8eL8-R8) [[2]](diffhunk://#diff-7ea1cd7bd5d16299a0abd33128e8d0a8bc04146f6b00c07bcd3cc0aad813c229L6-R6)
* Commented out the local `pylint` hook configuration in `.pre-commit-config.yaml`.

Metrics integration:

* Added a new `MetricsClient` class in `src/api_to_dataframe/utils/metrics.py` to handle metrics tracking using Datadog.
* Integrated `MetricsClient` into `ClientBuilder` class to track metrics for client building and API data fetching processes. [[1]](diffhunk://#diff-322d2cd46f4a1fbf45043b54a8cd900930a5f508880b8b1557b7ff5d0a59fe2fR4) [[2]](diffhunk://#diff-322d2cd46f4a1fbf45043b54a8cd900930a5f508880b8b1557b7ff5d0a59fe2fR56-R59) [[3]](diffhunk://#diff-322d2cd46f4a1fbf45043b54a8cd900930a5f508880b8b1557b7ff5d0a59fe2fR73-R84) [[4]](diffhunk://#diff-322d2cd46f4a1fbf45043b54a8cd900930a5f508880b8b1557b7ff5d0a59fe2fR102-R106)