### PR TITLE
Refactor normalization pipeline and add transformer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,47 @@ df = client.api_to_dataframe(data)
 print(df)
 ```
 
+### Normalization options
+
+`ClientBuilder.api_to_dataframe` accepts keyword arguments that are
+forwarded to [`pandas.json_normalize`](https://pandas.pydata.org/docs/reference/api/pandas.json_normalize.html).
+This makes it possible to flatten nested payloads and include metadata
+fields easily:
+
+```python
+payload = {
+    "meta": {"page": 1},
+    "items": [
+        {"id": 1, "value": "alpha"},
+        {"id": 2, "value": "beta"},
+    ],
+}
+
+client = ClientBuilder(endpoint="https://api.example.com")
+
+df = client.api_to_dataframe(
+    payload,
+    record_path="items",
+    meta=[["meta", "page"]],
+    errors="ignore",  # optionally avoid raising when paths are missing
+)
+```
+
+When complex transformations are required before normalization, provide a
+`transformer` callable to the constructor. The callable receives the JSON
+payload returned by `get_api_data` and can return any structure supported
+by `pandas.json_normalize`:
+
+```python
+client = ClientBuilder(
+    endpoint="https://api.example.com",
+    transformer=lambda payload: payload["data"],
+)
+
+data = client.get_api_data()
+df = client.api_to_dataframe(data)
+```
+
 ## Important notes:
 * **Opcionals Parameters:** The params timeout, retry_strategy and headers are opcionals.
 * **Default Params Value:** By default the quantity of retries is 3 and the time between retries is 1 second, but you can define manually.

--- a/src/api_to_dataframe/controller/client_builder.py
+++ b/src/api_to_dataframe/controller/client_builder.py
@@ -1,3 +1,5 @@
+from typing import Any, Callable, Optional, Sequence, Union
+
 from api_to_dataframe.models.retainer import retry_strategies, Strategies
 from api_to_dataframe.models.get_data import GetData
 from api_to_dataframe.utils.logger import logger
@@ -12,6 +14,7 @@ class ClientBuilder:
         retries: int = 3,
         initial_delay: int = 1,
         connection_timeout: int = 1,
+        transformer: Optional[Callable[[Any], Any]] = None,
     ):
         """
         Initializes the ClientBuilder object.
@@ -23,6 +26,8 @@ class ClientBuilder:
             retries (int): The number of times to retry a failed request. Defaults to 3.
             initial_delay (int): The delay between retries in seconds. Defaults to 1.
             connection_timeout (int): The timeout for the connection in seconds. Defaults to 1.
+            transformer (Optional[Callable[[Any], Any]]): Optional callable to
+                transform the JSON payload before DataFrame normalization.
 
         Raises:
             ValueError: If endpoint is an empty string.
@@ -56,6 +61,7 @@ class ClientBuilder:
         self.headers = headers
         self.retries = retries
         self.delay = initial_delay
+        self.transformer = transformer
 
     @retry_strategies
     def get_api_data(self):
@@ -77,19 +83,39 @@ class ClientBuilder:
 
         return response.json()
 
-    @staticmethod
-    def api_to_dataframe(response: dict):
-        """
-        Converts an API response to a DataFrame.
-
-        This function takes a dictionary response from an API,
-        uses the `to_dataframe` function from the `GetData` class
-        to convert it into a DataFrame, and logs the operation as successful.
+    def api_to_dataframe(
+        self,
+        response: Any,
+        *,
+        record_path: Optional[Union[str, Sequence[str]]] = None,
+        meta: Optional[Sequence[Union[str, Sequence[str]]]] = None,
+        errors: str = "raise",
+        max_level: Optional[int] = None,
+    ):
+        """Normalize an API response into a pandas DataFrame.
 
         Args:
-            response (dict): The dictionary containing the API response.
+            response (Any): The already decoded API response payload.
+            record_path (Optional[Union[str, Sequence[str]]]): Path to nested
+                records passed to :func:`pandas.json_normalize`.
+            meta (Optional[Sequence[Union[str, Sequence[str]]]]): Metadata keys to
+                include as columns in the result.
+            errors (str): Error handling strategy to forward to
+                :func:`pandas.json_normalize` ("raise" or "ignore").
+            max_level (Optional[int]): Maximum depth for record flattening.
 
         Returns:
-            DataFrame: A pandas DataFrame containing the data from the API response.
+            pandas.DataFrame: A DataFrame containing the normalized payload.
         """
-        return GetData.to_dataframe(response)
+
+        data = response
+        if self.transformer is not None:
+            data = self.transformer(response)
+
+        return GetData.to_dataframe(
+            data,
+            record_path=record_path,
+            meta=meta,
+            errors=errors,
+            max_level=max_level,
+        )

--- a/src/api_to_dataframe/models/get_data.py
+++ b/src/api_to_dataframe/models/get_data.py
@@ -1,5 +1,8 @@
-import requests
+from typing import Any, Optional, Sequence, Union
+
 import pandas as pd
+import requests
+
 from api_to_dataframe.utils.logger import logger
 
 
@@ -15,13 +18,54 @@ class GetData:
         return response
 
     @staticmethod
-    def to_dataframe(response):
-        df = pd.DataFrame(response)
+    def to_dataframe(
+        response: Any,
+        *,
+        record_path: Optional[Union[str, Sequence[str]]] = None,
+        meta: Optional[Sequence[Union[str, Sequence[str]]]] = None,
+        errors: str = "raise",
+        max_level: Optional[int] = None,
+    ) -> pd.DataFrame:
+        """Convert an API response object into a pandas DataFrame.
 
-        # Check if DataFrame is empty
-        if df.empty:
+        Args:
+            response (Any): The API response already decoded to a Python object.
+            record_path (Optional[Union[str, Sequence[str]]]): The path to records for
+                nested data structures accepted by :func:`pandas.json_normalize`.
+            meta (Optional[Sequence[Union[str, Sequence[str]]]]): Additional metadata
+                to include as columns in the resulting DataFrame.
+            errors (str): Error handling strategy from
+                :func:`pandas.json_normalize` ("raise" or "ignore").
+            max_level (Optional[int]): Max depth to normalize nested records.
+
+        Returns:
+            pandas.DataFrame: A DataFrame containing the normalized data.
+
+        Raises:
+            ValueError: If the normalization results in an empty DataFrame while the
+                error strategy is not set to ``"ignore"``.
+        """
+
+        if response is None or response == "":
+            error_msg = "::: Response payload is empty :::"
+            logger.error(error_msg)
+            raise ValueError(error_msg)
+
+        try:
+            dataframe = pd.json_normalize(
+                response,
+                record_path=record_path,
+                meta=meta,
+                errors=errors,
+                max_level=max_level,
+            )
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.error("::: Failed to normalize response: %s :::", exc)
+            raise
+
+        if dataframe.empty and errors != "ignore":
             error_msg = "::: DataFrame is empty :::"
             logger.error(error_msg)
             raise ValueError(error_msg)
 
-        return df
+        return dataframe

--- a/tests/test_controller_client_builder.py
+++ b/tests/test_controller_client_builder.py
@@ -1,5 +1,7 @@
-import pytest
+"""Tests for the ClientBuilder controller."""
+
 import pandas as pd
+import pytest
 import responses
 
 from api_to_dataframe import ClientBuilder, RetryStrategies
@@ -7,6 +9,8 @@ from api_to_dataframe import ClientBuilder, RetryStrategies
 
 @pytest.fixture()
 def client_setup():
+    """Provide a ClientBuilder instance for constructor related tests."""
+
     new_client = ClientBuilder(
         endpoint="https://economia.awesomeapi.com.br/last/USD-BRL"
     )
@@ -15,13 +19,17 @@ def client_setup():
 
 @pytest.fixture()
 def response_setup():
-    new_client = ClientBuilder(
-        endpoint="https://economia.awesomeapi.com.br/last/USD-BRL"
-    )
-    return new_client.get_api_data()
+    """Provide a simple payload used to build DataFrames."""
+
+    return [
+        {"code": "USD", "name": "Dollar"},
+        {"code": "BRL", "name": "Real"},
+    ]
 
 
 def test_constructor_raises():
+    """Ensure validation errors are raised for invalid constructor arguments."""
+
     with pytest.raises(ValueError):
         ClientBuilder(endpoint="")
 
@@ -59,6 +67,8 @@ def test_constructor_raises():
 
 
 def test_constructor_with_param(client_setup):  # pylint: disable=redefined-outer-name
+    """Ensure the endpoint argument is stored on the instance."""
+
     expected_result = "https://economia.awesomeapi.com.br/last/USD-BRL"
     new_client = client_setup
     assert new_client.endpoint == expected_result
@@ -87,14 +97,29 @@ def test_constructor_with_retry_strategy():
     assert client.delay == 2
 
 
+@responses.activate
 def test_response_to_json(client_setup):  # pylint: disable=redefined-outer-name
+    """Ensure the API response is decoded to JSON."""
+
     new_client = client_setup
+    endpoint = new_client.endpoint
+
+    responses.add(
+        responses.GET,
+        endpoint,
+        json={"status": "ok"},
+        status=200,
+    )
+
     response = new_client.get_api_data()  # pylint: disable=protected-access
     assert isinstance(response, dict)
 
 
 def test_to_dataframe(response_setup):  # pylint: disable=redefined-outer-name
-    df = ClientBuilder.api_to_dataframe(response_setup)
+    """Ensure responses are converted into DataFrames using instance method."""
+
+    client = ClientBuilder(endpoint="https://economia.awesomeapi.com.br/last/USD-BRL")
+    df = client.api_to_dataframe(response_setup)
     assert isinstance(df, pd.DataFrame)
 
 
@@ -118,3 +143,26 @@ def test_get_api_data_with_mocked_response():
     assert response == expected_data
     assert len(responses.calls) == 1
     assert responses.calls[0].request.url == endpoint
+
+
+def test_api_to_dataframe_supports_custom_normalization():
+    """Ensure normalization parameters are forwarded to the GetData helper."""
+
+    payload = {
+        "meta": {"page": 1},
+        "items": [
+            {"id": 1, "name": "First"},
+            {"id": 2, "name": "Second"},
+        ],
+    }
+
+    client = ClientBuilder(endpoint="https://economia.awesomeapi.com.br/last/USD-BRL")
+
+    dataframe = client.api_to_dataframe(
+        payload,
+        record_path="items",
+        meta=[["meta", "page"]],
+    )
+
+    assert list(dataframe.columns) == ["id", "name", "meta.page"]
+    assert dataframe.iloc[0]["meta.page"] == 1

--- a/tests/test_models_get_data.py
+++ b/tests/test_models_get_data.py
@@ -1,99 +1,142 @@
+"""Tests for the GetData model utilities."""
+
+import json
+from typing import Any
+
+import pandas as pd
 import pytest
 import requests
 import responses
-import pandas as pd
-import json
 
-from api_to_dataframe.models.get_data import GetData
 from api_to_dataframe.controller.client_builder import ClientBuilder
+from api_to_dataframe.models.get_data import GetData
 
 
-def test_to_dataframe():
+def test_to_dataframe_rejects_empty_string() -> None:
+    """Ensure a string payload without data raises a ValueError."""
+
     with pytest.raises(ValueError):
         GetData.to_dataframe("")
 
 
-@responses.activate
-def test_to_emp_dataframe():
-    endpoint = "https://api.exemplo.com"
-    expected_response = {}
+def test_to_dataframe_rejects_empty_list_by_default() -> None:
+    """Validate that an empty iterable raises a ValueError when using default settings."""
 
-    responses.add(responses.GET, endpoint, json=expected_response, status=200)
+    with pytest.raises(ValueError):
+        GetData.to_dataframe([])
+
+
+def test_to_dataframe_allows_ignore_errors_for_empty_payload() -> None:
+    """Confirm that ignoring errors returns an empty DataFrame instead of raising."""
+
+    dataframe = GetData.to_dataframe([], errors="ignore")
+
+    assert isinstance(dataframe, pd.DataFrame)
+    assert dataframe.empty
+
+
+def test_to_dataframe_flattens_nested_structure() -> None:
+    """Check that nested dictionaries are flattened using pandas.json_normalize."""
+
+    payload = [
+        {"user": {"id": 1, "profile": {"name": "User1", "active": True}}},
+        {"user": {"id": 2, "profile": {"name": "User2", "active": False}}},
+    ]
+
+    dataframe = GetData.to_dataframe(payload, max_level=1)
+
+    assert list(dataframe.columns) == ["user.id", "user.profile"]
+    assert dataframe.iloc[0]["user.id"] == 1
+    assert dataframe.iloc[1]["user.profile"].get("name") == "User2"
+
+
+def test_to_dataframe_with_custom_record_path_and_meta() -> None:
+    """Ensure record_path and meta arguments are forwarded to pandas.json_normalize."""
+
+    payload = {
+        "metadata": {"batch": "A", "source": "unit-test"},
+        "items": [
+            {"id": 1, "value": "alpha"},
+            {"id": 2, "value": "beta"},
+        ],
+    }
+
+    dataframe = GetData.to_dataframe(
+        payload,
+        record_path="items",
+        meta=["metadata"],
+    )
+
+    assert "metadata" in dataframe.columns
+    assert dataframe.iloc[0]["metadata"]["batch"] == "A"
+    assert dataframe.iloc[1]["value"] == "beta"
+
+
+@responses.activate
+def test_to_dataframe_handles_nested_list_via_record_path() -> None:
+    """Validate normalization when the response is retrieved from the HTTP client."""
+
+    endpoint = "https://api.example.com/nested"
+    payload = {
+        "meta": {"page": 1},
+        "results": [
+            {"id": 1, "attributes": {"name": "Item1"}},
+            {"id": 2, "attributes": {"name": "Item2"}},
+        ],
+    }
+
+    responses.add(responses.GET, endpoint, json=payload, status=200)
 
     client = ClientBuilder(endpoint=endpoint)
     response = client.get_api_data()
 
-    with pytest.raises(ValueError):
-        GetData.to_dataframe(response)
+    dataframe = client.api_to_dataframe(
+        response,
+        record_path="results",
+        meta=[["meta", "page"]],
+    )
+
+    assert list(dataframe.columns) == ["id", "attributes.name", "meta.page"]
+    assert dataframe.iloc[0]["meta.page"] == 1
+    assert dataframe.iloc[1]["attributes.name"] == "Item2"
 
 
 @responses.activate
-def test_valid_dataframe_conversion():
-    """Test successful conversion of valid data to DataFrame"""
-    # A estrutura do dict afeta como o pandas cria o DataFrame
-    # Os dados precisam estar em uma lista para serem convertidos em linhas
-    valid_data = [{"id": 1, "name": "Test"}, {"id": 2, "name": "Test2"}]
-    df = GetData.to_dataframe(valid_data)
+def test_to_dataframe_supports_transformer_before_normalization() -> None:
+    """Check that ClientBuilder applies a transformer before delegating to GetData."""
 
-    assert isinstance(df, pd.DataFrame)
-    assert len(df) == 2
-    assert "id" in df.columns
-    assert "name" in df.columns
-    assert df.iloc[0]["id"] == 1
-    assert df.iloc[1]["name"] == "Test2"
+    endpoint = "https://api.example.com/items"
+    payload = {"data": [{"id": 1}, {"id": 2}]}
 
+    responses.add(responses.GET, endpoint, json=payload, status=200)
 
-@responses.activate
-def test_nested_data_conversion():
-    """Test conversion of nested data structures"""
-    # Lista de dicionários é mais adequado para converter em DataFrame
-    nested_data = [
-        {"user": {"id": 1, "profile": {"name": "User1"}}},
-        {"user": {"id": 2, "profile": {"name": "User2"}}}
-    ]
+    def transformer(raw: Any) -> Any:
+        return raw["data"]
 
-    # Convert to string and back to dict to simulate JSON response
-    json_str = json.dumps(nested_data)
-    response_list = json.loads(json_str)
+    client = ClientBuilder(endpoint=endpoint, transformer=transformer)
+    response = client.get_api_data()
 
-    df = GetData.to_dataframe(response_list)
-    assert isinstance(df, pd.DataFrame)
-    assert not df.empty
-    assert len(df) == 2
-    # Verificar estrutura das colunas
-    assert "user" in df.columns
+    dataframe = client.api_to_dataframe(response)
+
+    assert isinstance(dataframe, pd.DataFrame)
+    assert list(dataframe["id"]) == [1, 2]
 
 
 @responses.activate
-def test_http_error():
+def test_http_error() -> None:
+    """Ensure HTTP errors are propagated when the API returns a bad status."""
+
     endpoint = "https://api.exemplo.com"
-    expected_response = {}
-
-    responses.add(responses.GET, endpoint, json=expected_response, status=400)
+    responses.add(responses.GET, endpoint, json={}, status=400)
 
     with pytest.raises(requests.exceptions.HTTPError):
         GetData.get_response(endpoint=endpoint, headers={}, connection_timeout=10)
 
 
 @responses.activate
-def test_http_error_with_custom_message():
-    """Test HTTP error with custom error message in response"""
-    endpoint = "https://api.exemplo.com/error"
-    error_response = {"error": "Bad Request", "message": "Invalid parameters"}
+def test_timeout_error() -> None:
+    """Ensure timeout exceptions are surfaced to callers."""
 
-    responses.add(
-        responses.GET,
-        endpoint,
-        json=error_response,
-        status=400
-    )
-
-    with pytest.raises(requests.exceptions.HTTPError):
-        response = GetData.get_response(endpoint=endpoint, headers={}, connection_timeout=10)
-
-
-@responses.activate
-def test_timeout_error():
     endpoint = "https://api.exemplo.com"
 
     responses.add(responses.GET, endpoint, body=requests.exceptions.Timeout())
@@ -103,26 +146,27 @@ def test_timeout_error():
 
 
 @responses.activate
-def test_request_exception():
+def test_request_exception() -> None:
+    """Ensure generic request exceptions are raised when appropriate."""
+
     endpoint = "https://api.exemplo.com"
 
-    expected_response = {}
-
-    responses.add(responses.GET, endpoint, json=expected_response, status=500)
+    responses.add(responses.GET, endpoint, json={}, status=500)
 
     with pytest.raises(requests.exceptions.RequestException):
         GetData.get_response(endpoint=endpoint, headers={}, connection_timeout=10)
 
 
 @responses.activate
-def test_headers_passed_correctly():
-    """Test that headers are correctly passed to the request"""
+def test_headers_passed_correctly() -> None:
+    """Verify that custom headers are forwarded to the HTTP request."""
+
     endpoint = "https://api.exemplo.com/headers"
     expected_response = {"success": True}
     custom_headers = {
         "Authorization": "Bearer test-token",
         "X-Custom-Header": "test-value",
-        "Content-Type": "application/json"
+        "Content-Type": "application/json",
     }
 
     def match_headers(request):
@@ -135,13 +179,13 @@ def test_headers_passed_correctly():
         responses.GET,
         endpoint,
         callback=match_headers,
-        content_type="application/json"
+        content_type="application/json",
     )
 
     response = GetData.get_response(
         endpoint=endpoint,
         headers=custom_headers,
-        connection_timeout=10
+        connection_timeout=10,
     )
 
     assert response.status_code == 200


### PR DESCRIPTION
## Summary
- refactor GetData.to_dataframe to use pandas.json_normalize with configurable options
- allow ClientBuilder instances to accept an optional transformer and forward normalization parameters
- expand unit tests for nested payloads, empty inputs, and normalization settings while updating documentation

## Testing
- `poetry run pylint src/api_to_dataframe`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_690ba1465964832bb9cb2fd6fa0a9b1c