### PR TITLE
Add pagination support and aggregate API results

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ poetry add api-to-dataframe
 
 ``` python
 ## Importing library
-from api_to_dataframe import ClientBuilder, RetryStrategies
+from api_to_dataframe import ClientBuilder, PaginationStrategy, RetryStrategies
 
 # Create a client for simple ingest data from API (timeout 1 second)
 client = ClientBuilder(endpoint="https://api.example.com")
@@ -77,6 +77,30 @@ df = client.api_to_dataframe(data)
 # Display the DataFrame
 print(df)
 ```
+
+### Working with pagination
+
+```python
+from api_to_dataframe import ClientBuilder, PaginationStrategy
+
+client = ClientBuilder(endpoint="https://api.example.com/resources")
+
+result = client.with_pagination(
+    PaginationStrategy.OFFSET_LIMIT,
+    limit=100,
+    results_key="items",
+).get_api_data()
+
+print(result.metadata["pages"])  # total pages retrieved
+records = result.as_records()
+dataframe = ClientBuilder.api_to_dataframe(result)
+```
+
+Each call to `get_api_data` returns a `DataFetchResult` object containing:
+
+* `payloads`: the raw response for every page requested;
+* `records`: flattened records suitable for DataFrame conversion;
+* `metadata`: strategy details such as the number of pages fetched and the last pagination parameters used.
 
 ## Important notes:
 * **Opcionals Parameters:** The params timeout, retry_strategy and headers are opcionals.

--- a/src/api_to_dataframe/__init__.py
+++ b/src/api_to_dataframe/__init__.py
@@ -1,2 +1,10 @@
 from .controller.client_builder import ClientBuilder
+from .models.pagination import DataFetchResult, PaginationStrategy
 from .models.retainer import Strategies as RetryStrategies
+
+__all__ = [
+    "ClientBuilder",
+    "RetryStrategies",
+    "PaginationStrategy",
+    "DataFetchResult",
+]

--- a/src/api_to_dataframe/controller/client_builder.py
+++ b/src/api_to_dataframe/controller/client_builder.py
@@ -1,5 +1,17 @@
+from copy import deepcopy
+from typing import Any, Dict, Iterator, List, Optional, Union
+
 from api_to_dataframe.models.retainer import retry_strategies, Strategies
 from api_to_dataframe.models.get_data import GetData
+from api_to_dataframe.models.pagination import (
+    DataFetchResult,
+    PaginationConfig,
+    PaginationStrategy,
+    PaginationStep,
+    cursor_iterator,
+    offset_limit_iterator,
+    page_iterator,
+)
 from api_to_dataframe.utils.logger import logger
 
 
@@ -56,6 +68,46 @@ class ClientBuilder:
         self.headers = headers
         self.retries = retries
         self.delay = initial_delay
+        self.pagination_config: Optional[PaginationConfig] = None
+
+    def with_pagination(self, strategy: Union[PaginationStrategy, str], **strategy_kwargs) -> "ClientBuilder":
+        """Configure pagination metadata to be used when fetching data."""
+
+        if isinstance(strategy, PaginationStrategy):
+            strategy_value = strategy
+        elif isinstance(strategy, str):
+            try:
+                strategy_value = PaginationStrategy(strategy.lower())
+            except ValueError as exc:
+                error_msg = (
+                    "Unsupported pagination strategy. Use one of: "
+                    f"{', '.join(item.value for item in PaginationStrategy)}"
+                )
+                logger.error(error_msg)
+                raise ValueError(error_msg) from exc
+        else:
+            error_msg = "Strategy must be a PaginationStrategy or string value"
+            logger.error(error_msg)
+            raise TypeError(error_msg)
+
+        if strategy_value == PaginationStrategy.OFFSET_LIMIT:
+            limit = strategy_kwargs.get("limit")
+            if limit is None or not isinstance(limit, int) or limit <= 0:
+                error_msg = "Offset/limit strategy requires a positive integer 'limit'"
+                logger.error(error_msg)
+                raise ValueError(error_msg)
+        if strategy_value == PaginationStrategy.PAGE:
+            start_page = strategy_kwargs.get("start_page", 1)
+            if not isinstance(start_page, int) or start_page <= 0:
+                error_msg = "Page strategy requires a positive integer 'start_page'"
+                logger.error(error_msg)
+                raise ValueError(error_msg)
+
+        self.pagination_config = PaginationConfig(
+            strategy=strategy_value,
+            params=deepcopy(strategy_kwargs),
+        )
+        return self
 
     @retry_strategies
     def get_api_data(self):
@@ -69,16 +121,49 @@ class ClientBuilder:
         Returns:
             dict: The JSON response from the API as a dictionary.
         """
-        response = GetData.get_response(
-            endpoint=self.endpoint,
-            headers=self.headers,
-            connection_timeout=self.connection_timeout,
-        )
+        if self.pagination_config is None:
+            response = GetData.get_response(
+                endpoint=self.endpoint,
+                headers=self.headers,
+                connection_timeout=self.connection_timeout,
+            )
+            payload = response.json()
+            return DataFetchResult(
+                payloads=[payload],
+                records=_normalise_records(payload, results_key=None),
+                metadata={"strategy": "single", "pages": 1},
+            )
 
-        return response.json()
+        iterator = self._build_iterator()
+        payloads = []
+        records = []
+        metadata: Dict[str, Any] = {
+            "strategy": self.pagination_config.strategy.value,
+            "params": deepcopy(self.pagination_config.params),
+            "pages": 0,
+        }
+        results_key = self.pagination_config.params.get("results_key")
+        last_params: Optional[Dict[str, Any]] = None
+        last_cursor: Optional[str] = None
+
+        for step in iterator:
+            payloads.append(step.payload)
+            metadata["pages"] += 1
+            last_params = step.params
+            last_cursor = step.cursor
+
+            step_records = _normalise_records(step.payload, results_key=results_key)
+            records.extend(step_records)
+
+        if last_params is not None:
+            metadata["last_params"] = last_params
+        if self.pagination_config.strategy == PaginationStrategy.CURSOR:
+            metadata["last_cursor"] = last_cursor
+
+        return DataFetchResult(payloads=payloads, records=records, metadata=metadata)
 
     @staticmethod
-    def api_to_dataframe(response: dict):
+    def api_to_dataframe(response: Any):
         """
         Converts an API response to a DataFrame.
 
@@ -92,4 +177,49 @@ class ClientBuilder:
         Returns:
             DataFrame: A pandas DataFrame containing the data from the API response.
         """
-        return GetData.to_dataframe(response)
+        if isinstance(response, DataFetchResult):
+            records = response.as_records()
+        else:
+            records = response
+
+        return GetData.to_dataframe(records)
+
+    def _build_iterator(self) -> Iterator[PaginationStep]:
+        """Create the configured pagination iterator."""
+
+        assert self.pagination_config is not None  # for mypy style checking
+        fetch_page = self._fetch_page
+        params = self.pagination_config.params
+
+        if self.pagination_config.strategy == PaginationStrategy.OFFSET_LIMIT:
+            return offset_limit_iterator(fetch_page, **params)
+        if self.pagination_config.strategy == PaginationStrategy.PAGE:
+            return page_iterator(fetch_page, **params)
+        if self.pagination_config.strategy == PaginationStrategy.CURSOR:
+            return cursor_iterator(fetch_page, **params)
+
+        error_msg = "Unsupported pagination strategy configured"
+        logger.error(error_msg)
+        raise ValueError(error_msg)
+
+    def _fetch_page(self, params: Dict[str, Any]) -> Any:
+        """Fetch a single page applying the current pagination parameters."""
+
+        response = GetData.get_response(
+            endpoint=self.endpoint,
+            headers=self.headers,
+            connection_timeout=self.connection_timeout,
+            params=params if params else None,
+        )
+        return response.json()
+
+
+def _normalise_records(payload: Any, results_key: Optional[str]) -> List[Any]:
+    """Normalise payloads into a list of records."""
+
+    if isinstance(payload, list):
+        return payload
+    if isinstance(payload, dict) and results_key is not None:
+        records = payload.get(results_key, [])
+        return records if isinstance(records, list) else []
+    return [payload]

--- a/src/api_to_dataframe/models/get_data.py
+++ b/src/api_to_dataframe/models/get_data.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import requests
 import pandas as pd
 from api_to_dataframe.utils.logger import logger
@@ -5,9 +7,15 @@ from api_to_dataframe.utils.logger import logger
 
 class GetData:
     @staticmethod
-    def get_response(endpoint: str, headers: dict, connection_timeout: int):
+    def get_response(endpoint: str, headers: dict, connection_timeout: int, params: Optional[dict] = None):
+        """Execute a GET request against the target endpoint."""
         # Make the request
-        response = requests.get(endpoint, timeout=connection_timeout, headers=headers)
+        response = requests.get(
+            endpoint,
+            timeout=connection_timeout,
+            headers=headers,
+            params=params,
+        )
 
         # Attempt to raise for status to catch errors
         response.raise_for_status()

--- a/src/api_to_dataframe/models/pagination.py
+++ b/src/api_to_dataframe/models/pagination.py
@@ -1,0 +1,192 @@
+"""Pagination helpers and data structures."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Callable, Dict, Iterator, List, Optional
+
+
+class PaginationStrategy(str, Enum):
+    """Describe the supported pagination strategies."""
+
+    OFFSET_LIMIT = "offset_limit"
+    PAGE = "page"
+    CURSOR = "cursor"
+
+
+@dataclass
+class PaginationConfig:
+    """Store pagination strategy metadata for the client."""
+
+    strategy: PaginationStrategy
+    params: Dict[str, Any]
+
+
+@dataclass
+class PaginationStep:
+    """Hold a single pagination iteration payload and context."""
+
+    payload: Any
+    params: Dict[str, Any]
+    cursor: Optional[str] = None
+
+
+@dataclass
+class DataFetchResult:
+    """Represent the aggregated result of a paginated fetch."""
+
+    payloads: List[Any]
+    records: List[Any]
+    metadata: Dict[str, Any]
+
+    def as_records(self) -> List[Any]:
+        """Return the aggregated list of records."""
+
+        return self.records
+
+
+def offset_limit_iterator(
+    fetch_page: Callable[[Dict[str, Any]], Any],
+    *,
+    limit: int,
+    offset: int = 0,
+    offset_param: str = "offset",
+    limit_param: str = "limit",
+    max_pages: Optional[int] = None,
+    results_key: Optional[str] = None,
+    stop_on_short_page: bool = True,
+) -> Iterator[PaginationStep]:
+    """Iterate over pages using an ``offset``/``limit`` pattern."""
+
+    current_offset = offset
+    page_number = 0
+
+    while True:
+        params = {offset_param: current_offset, limit_param: limit}
+        page = fetch_page(params)
+        yield PaginationStep(payload=page, params=params)
+        page_number += 1
+
+        if _should_stop(page, results_key=results_key, expected_length=limit, stop_on_short_page=stop_on_short_page):
+            break
+
+        current_offset += limit
+        if max_pages is not None and page_number >= max_pages:
+            break
+
+
+def page_iterator(
+    fetch_page: Callable[[Dict[str, Any]], Any],
+    *,
+    start_page: int = 1,
+    page_param: str = "page",
+    max_pages: Optional[int] = None,
+    results_key: Optional[str] = None,
+    stop_on_empty: bool = True,
+) -> Iterator[PaginationStep]:
+    """Iterate over pages using numeric page indexes."""
+
+    current_page = start_page
+    page_number = 0
+
+    while True:
+        params = {page_param: current_page}
+        page = fetch_page(params)
+        yield PaginationStep(payload=page, params=params)
+        page_number += 1
+
+        if _should_stop(page, results_key=results_key, stop_on_empty=stop_on_empty):
+            break
+
+        current_page += 1
+        if max_pages is not None and page_number >= max_pages:
+            break
+
+
+def cursor_iterator(
+    fetch_page: Callable[[Dict[str, Any]], Any],
+    *,
+    cursor_param: str = "cursor",
+    initial_cursor: Optional[str] = None,
+    next_cursor_key: str = "next_cursor",
+    max_pages: Optional[int] = None,
+    results_key: Optional[str] = None,
+    stop_on_empty: bool = True,
+) -> Iterator[PaginationStep]:
+    """Iterate using cursor-based pagination."""
+
+    cursor = initial_cursor
+    page_number = 0
+
+    while True:
+        params: Dict[str, Any] = {}
+        if cursor is not None:
+            params[cursor_param] = cursor
+
+        page = fetch_page(params)
+        next_cursor = _extract_next_cursor(page, next_cursor_key)
+        yield PaginationStep(payload=page, params=params, cursor=next_cursor)
+        page_number += 1
+
+        if _should_stop(page, results_key=results_key, stop_on_empty=stop_on_empty):
+            break
+
+        if max_pages is not None and page_number >= max_pages:
+            break
+
+        if next_cursor is None:
+            break
+
+        cursor = next_cursor
+
+
+def _should_stop(
+    page: Any,
+    *,
+    results_key: Optional[str],
+    expected_length: Optional[int] = None,
+    stop_on_short_page: bool = False,
+    stop_on_empty: bool = False,
+) -> bool:
+    """Evaluate whether pagination should stop based on the payload."""
+
+    if page is None:
+        return True
+
+    items = _extract_items(page, results_key)
+    if items is None:
+        return False
+
+    if stop_on_empty and len(items) == 0:
+        return True
+
+    if expected_length is not None and stop_on_short_page and len(items) < expected_length:
+        return True
+
+    return False
+
+
+def _extract_items(page: Any, results_key: Optional[str]) -> Optional[List[Any]]:
+    """Extract a list of items from the payload when possible."""
+
+    if isinstance(page, list):
+        return page
+
+    if isinstance(page, dict):
+        if results_key is None:
+            return None
+        items = page.get(results_key, [])
+        return items if isinstance(items, list) else []
+
+    return None
+
+
+def _extract_next_cursor(page: Any, next_cursor_key: str) -> Optional[str]:
+    """Extract the cursor value from a response payload."""
+
+    if isinstance(page, dict):
+        cursor = page.get(next_cursor_key)
+        if isinstance(cursor, str) or cursor is None:
+            return cursor
+    return None

--- a/src/api_to_dataframe/models/pagination.py
+++ b/src/api_to_dataframe/models/pagination.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Callable, Dict, Iterator, List, Optional
+from typing import Any, Callable, Dict, Iterator, List, Optional, Union
+
+
+JSONValue = Union[None, bool, int, float, str, List["JSONValue"], Dict[str, "JSONValue"]]
 
 
 class PaginationStrategy(str, Enum):
@@ -29,7 +32,7 @@ class PaginationStep:
 
     payload: Any
     params: Dict[str, Any]
-    cursor: Optional[str] = None
+    cursor: Optional[JSONValue] = None
 
 
 @dataclass
@@ -108,7 +111,7 @@ def cursor_iterator(
     fetch_page: Callable[[Dict[str, Any]], Any],
     *,
     cursor_param: str = "cursor",
-    initial_cursor: Optional[str] = None,
+    initial_cursor: Optional[JSONValue] = None,
     next_cursor_key: str = "next_cursor",
     max_pages: Optional[int] = None,
     results_key: Optional[str] = None,
@@ -182,11 +185,28 @@ def _extract_items(page: Any, results_key: Optional[str]) -> Optional[List[Any]]
     return None
 
 
-def _extract_next_cursor(page: Any, next_cursor_key: str) -> Optional[str]:
+def _extract_next_cursor(page: Any, next_cursor_key: str) -> Optional[JSONValue]:
     """Extract the cursor value from a response payload."""
 
     if isinstance(page, dict):
         cursor = page.get(next_cursor_key)
-        if isinstance(cursor, str) or cursor is None:
+        if cursor is None:
+            return None
+        if _is_json_serializable(cursor):
             return cursor
     return None
+
+
+def _is_json_serializable(value: Any) -> bool:
+    """Check whether a value can be represented as JSON."""
+
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return True
+
+    if isinstance(value, list):
+        return all(_is_json_serializable(item) for item in value)
+
+    if isinstance(value, dict):
+        return all(isinstance(key, str) and _is_json_serializable(item) for key, item in value.items())
+
+    return False

--- a/tests/test_controller_client_builder.py
+++ b/tests/test_controller_client_builder.py
@@ -2,26 +2,20 @@ import pytest
 import pandas as pd
 import responses
 
-from api_to_dataframe import ClientBuilder, RetryStrategies
+from api_to_dataframe import ClientBuilder, DataFetchResult, RetryStrategies
 
 
 @pytest.fixture()
 def client_setup():
-    new_client = ClientBuilder(
-        endpoint="https://economia.awesomeapi.com.br/last/USD-BRL"
-    )
+    """Create a basic ClientBuilder instance for tests."""
+
+    new_client = ClientBuilder(endpoint="https://economia.awesomeapi.com.br/last/USD-BRL")
     return new_client
 
 
-@pytest.fixture()
-def response_setup():
-    new_client = ClientBuilder(
-        endpoint="https://economia.awesomeapi.com.br/last/USD-BRL"
-    )
-    return new_client.get_api_data()
-
-
 def test_constructor_raises():
+    """Validate constructor argument validation logic."""
+
     with pytest.raises(ValueError):
         ClientBuilder(endpoint="")
 
@@ -59,6 +53,8 @@ def test_constructor_raises():
 
 
 def test_constructor_with_param(client_setup):  # pylint: disable=redefined-outer-name
+    """Ensure constructor stores the provided endpoint."""
+
     expected_result = "https://economia.awesomeapi.com.br/last/USD-BRL"
     new_client = client_setup
     assert new_client.endpoint == expected_result
@@ -87,14 +83,35 @@ def test_constructor_with_retry_strategy():
     assert client.delay == 2
 
 
+@responses.activate
 def test_response_to_json(client_setup):  # pylint: disable=redefined-outer-name
+    """Ensure get_api_data returns a DataFetchResult."""
+
     new_client = client_setup
-    response = new_client.get_api_data()  # pylint: disable=protected-access
-    assert isinstance(response, dict)
+    responses.add(
+        responses.GET,
+        new_client.endpoint,
+        json={"mocked": True},
+        status=200,
+    )
+    response = new_client.get_api_data()
+    assert isinstance(response, DataFetchResult)
+    assert response.metadata["strategy"] == "single"
 
 
-def test_to_dataframe(response_setup):  # pylint: disable=redefined-outer-name
-    df = ClientBuilder.api_to_dataframe(response_setup)
+@responses.activate
+def test_to_dataframe():
+    """Convert aggregated API data to DataFrame."""
+
+    client = ClientBuilder(endpoint="https://economia.awesomeapi.com.br/last/USD-BRL")
+    responses.add(
+        responses.GET,
+        client.endpoint,
+        json=[{"value": 1}],
+        status=200,
+    )
+    response = client.get_api_data()
+    df = ClientBuilder.api_to_dataframe(response)
     assert isinstance(df, pd.DataFrame)
 
 
@@ -115,6 +132,17 @@ def test_get_api_data_with_mocked_response():
     client = ClientBuilder(endpoint=endpoint)
     response = client.get_api_data()
 
-    assert response == expected_data
+    assert isinstance(response, DataFetchResult)
+    assert response.as_records() == [expected_data]
     assert len(responses.calls) == 1
     assert responses.calls[0].request.url == endpoint
+
+
+@responses.activate
+def test_with_pagination_invalid_strategy_value():
+    """Raise ValueError when configuring an unknown pagination strategy."""
+
+    client = ClientBuilder(endpoint="https://api.test.com/data")
+
+    with pytest.raises(ValueError):
+        client.with_pagination("unknown")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,44 +1,36 @@
-import pytest
-import responses
+"""Integration tests covering end-to-end flows."""
+
 import pandas as pd
+import responses
 
 from api_to_dataframe import ClientBuilder, RetryStrategies
 
 
 @responses.activate
 def test_full_flow_simple_api():
-    """Test the full flow from API request to DataFrame conversion with a simple API response"""
-    # Setup mock API
+    """Test the full flow from API request to DataFrame conversion with a simple API response."""
+
     endpoint = "https://api.example.com/data"
-    # Modificado para retornar lista diretamente, não encapsulado em dicionário
     api_response = [
         {"id": 1, "name": "Item 1", "price": 10.99},
         {"id": 2, "name": "Item 2", "price": 20.50},
-        {"id": 3, "name": "Item 3", "price": 5.25}
+        {"id": 3, "name": "Item 3", "price": 5.25},
     ]
 
-    responses.add(
-        responses.GET,
-        endpoint,
-        json=api_response,
-        status=200
-    )
+    responses.add(responses.GET, endpoint, json=api_response, status=200)
 
-    # Create client and fetch data
     client = ClientBuilder(
         endpoint=endpoint,
         retry_strategy=RetryStrategies.LINEAR_RETRY_STRATEGY,
         retries=3,
-        connection_timeout=5
+        connection_timeout=5,
     )
 
-    # Get API data
     response_data = client.get_api_data()
+    assert response_data.metadata["strategy"] == "single"
 
-    # Convert to DataFrame
     df = client.api_to_dataframe(response_data)
 
-    # Assertions
     assert isinstance(df, pd.DataFrame)
     assert len(df) == 3
     assert "id" in df.columns
@@ -51,45 +43,27 @@ def test_full_flow_simple_api():
 
 @responses.activate
 def test_full_flow_with_retry():
-    """Test the full flow with a failed request that succeeds after retry"""
+    """Test the full flow with a failed request that succeeds after retry."""
+
     endpoint = "https://api.example.com/data/retry"
-    # Modificado para lista direta, similar ao teste anterior
-    api_response = [
-        {"id": 1, "value": "Success after retry"}
-    ]
+    api_response = [{"id": 1, "value": "Success after retry"}]
 
-    # Add a failing response first
-    responses.add(
-        responses.GET,
-        endpoint,
-        status=500,
-        json={"error": "Server Error"}
-    )
+    responses.add(responses.GET, endpoint, status=500, json={"error": "Server Error"})
+    responses.add(responses.GET, endpoint, json=api_response, status=200)
 
-    # Add a successful response for subsequent requests
-    responses.add(
-        responses.GET,
-        endpoint,
-        json=api_response,
-        status=200
-    )
-
-    # Create client with retry strategy
     client = ClientBuilder(
         endpoint=endpoint,
         retry_strategy=RetryStrategies.LINEAR_RETRY_STRATEGY,
         retries=3,
         initial_delay=1,
-        connection_timeout=5
+        connection_timeout=5,
     )
 
-    # Get API data - should succeed after retry
     response_data = client.get_api_data()
+    assert response_data.metadata["strategy"] == "single"
 
-    # Convert to DataFrame
     df = client.api_to_dataframe(response_data)
 
-    # Assertions
     assert isinstance(df, pd.DataFrame)
     assert len(df) == 1
     assert "id" in df.columns
@@ -97,5 +71,4 @@ def test_full_flow_with_retry():
     assert df.iloc[0]["id"] == 1
     assert df.iloc[0]["value"] == "Success after retry"
 
-    # Verify we had 2 calls (first failed, second succeeded)
     assert len(responses.calls) == 2

--- a/tests/test_models_get_data.py
+++ b/tests/test_models_get_data.py
@@ -1,30 +1,38 @@
+import json
+
+import pandas as pd
 import pytest
 import requests
 import responses
-import pandas as pd
-import json
 
-from api_to_dataframe.models.get_data import GetData
+from api_to_dataframe import DataFetchResult
 from api_to_dataframe.controller.client_builder import ClientBuilder
+from api_to_dataframe.models.get_data import GetData
 
 
 def test_to_dataframe():
+    """Raise ValueError when provided with empty input data."""
+
     with pytest.raises(ValueError):
         GetData.to_dataframe("")
 
 
 @responses.activate
 def test_to_emp_dataframe():
+    """Propagate empty API payloads as dataframe errors."""
+
     endpoint = "https://api.exemplo.com"
-    expected_response = {}
+    expected_response = []
 
     responses.add(responses.GET, endpoint, json=expected_response, status=200)
 
     client = ClientBuilder(endpoint=endpoint)
     response = client.get_api_data()
 
+    assert isinstance(response, DataFetchResult)
+
     with pytest.raises(ValueError):
-        GetData.to_dataframe(response)
+        GetData.to_dataframe(response.as_records())
 
 
 @responses.activate
@@ -66,6 +74,8 @@ def test_nested_data_conversion():
 
 @responses.activate
 def test_http_error():
+    """Ensure HTTP errors raise the expected exception type."""
+
     endpoint = "https://api.exemplo.com"
     expected_response = {}
 
@@ -94,6 +104,8 @@ def test_http_error_with_custom_message():
 
 @responses.activate
 def test_timeout_error():
+    """Surface timeout exceptions raised by the requests layer."""
+
     endpoint = "https://api.exemplo.com"
 
     responses.add(responses.GET, endpoint, body=requests.exceptions.Timeout())
@@ -104,6 +116,8 @@ def test_timeout_error():
 
 @responses.activate
 def test_request_exception():
+    """Propagate generic request exceptions from the HTTP client."""
+
     endpoint = "https://api.exemplo.com"
 
     expected_response = {}
@@ -142,6 +156,32 @@ def test_headers_passed_correctly():
         endpoint=endpoint,
         headers=custom_headers,
         connection_timeout=10
+    )
+
+    assert response.status_code == 200
+    assert response.json() == expected_response
+
+
+@responses.activate
+def test_query_params_are_forwarded():
+    """Ensure query parameters are forwarded to the underlying request."""
+
+    endpoint = "https://api.exemplo.com/params"
+    expected_response = {"success": True}
+
+    responses.add(
+        responses.GET,
+        endpoint,
+        json=expected_response,
+        match=[responses.matchers.query_param_matcher({"offset": "10", "limit": "5"})],
+        status=200,
+    )
+
+    response = GetData.get_response(
+        endpoint=endpoint,
+        headers={},
+        connection_timeout=10,
+        params={"offset": 10, "limit": 5},
     )
 
     assert response.status_code == 200

--- a/tests/test_models_retainer.py
+++ b/tests/test_models_retainer.py
@@ -1,6 +1,7 @@
 import time
-import requests
+
 import pytest
+import requests
 
 from api_to_dataframe import ClientBuilder, RetryStrategies
 
@@ -8,6 +9,7 @@ from api_to_dataframe import ClientBuilder, RetryStrategies
 
 
 def test_linear_strategy():
+    """Ensure linear retry strategy waits the configured delay."""
     endpoint = "https://api-to-dataframe/"
     max_retries = 2
     client = ClientBuilder(
@@ -33,6 +35,7 @@ def test_linear_strategy():
 
 
 def test_no_retry_strategy():
+    """Verify that no retry strategy propagates the first exception."""
     endpoint = "https://api-to-dataframe/"
     client = ClientBuilder(
         endpoint=endpoint,
@@ -44,6 +47,7 @@ def test_no_retry_strategy():
 
 
 def test_exponential_strategy():
+    """Validate exponential backoff increases delay per retry."""
     endpoint = "https://api-to-dataframe/"
     max_retries = 2
     client = ClientBuilder(

--- a/tests/test_pagination_strategies.py
+++ b/tests/test_pagination_strategies.py
@@ -1,0 +1,135 @@
+"""Tests for the pagination helpers integrated with ClientBuilder."""
+
+import pytest
+import responses
+
+from api_to_dataframe import ClientBuilder, PaginationStrategy
+
+
+@responses.activate
+def test_offset_limit_pagination_collects_all_pages():
+    """Aggregate multiple offset/limit pages into a single result."""
+
+    endpoint = "https://api.example.com/resources"
+    first_page = {"items": [{"id": 1}, {"id": 2}]}
+    second_page = {"items": [{"id": 3}]}
+
+    responses.add(
+        responses.GET,
+        endpoint,
+        json=first_page,
+        match=[responses.matchers.query_param_matcher({"offset": "0", "limit": "2"})],
+        status=200,
+    )
+    responses.add(
+        responses.GET,
+        endpoint,
+        json=second_page,
+        match=[responses.matchers.query_param_matcher({"offset": "2", "limit": "2"})],
+        status=200,
+    )
+
+    client = ClientBuilder(endpoint=endpoint)
+    client.with_pagination(
+        PaginationStrategy.OFFSET_LIMIT,
+        limit=2,
+        results_key="items",
+    )
+
+    result = client.get_api_data()
+
+    assert result.metadata["strategy"] == PaginationStrategy.OFFSET_LIMIT.value
+    assert result.metadata["pages"] == 2
+    assert result.metadata["last_params"] == {"offset": 2, "limit": 2}
+    assert [item["id"] for item in result.records] == [1, 2, 3]
+
+
+@responses.activate
+def test_page_pagination_stops_on_empty_page():
+    """Stop requesting new pages once an empty list is returned."""
+
+    endpoint = "https://api.example.com/paged"
+    second_page = {"results": [{"page": 2}]}
+    empty_page = {"results": []}
+
+    responses.add(
+        responses.GET,
+        endpoint,
+        json=second_page,
+        match=[responses.matchers.query_param_matcher({"page": "2"})],
+        status=200,
+    )
+    responses.add(
+        responses.GET,
+        endpoint,
+        json=empty_page,
+        match=[responses.matchers.query_param_matcher({"page": "3"})],
+        status=200,
+    )
+
+    client = ClientBuilder(endpoint=endpoint)
+    client.with_pagination(
+        PaginationStrategy.PAGE,
+        start_page=2,
+        results_key="results",
+    )
+
+    result = client.get_api_data()
+
+    assert result.metadata["pages"] == 2
+    assert result.records == [{"page": 2}]
+    assert result.metadata["last_params"] == {"page": 3}
+
+
+@responses.activate
+def test_cursor_pagination_tracks_cursor_value():
+    """Cursor pagination returns combined records and cursor metadata."""
+
+    endpoint = "https://api.example.com/cursor"
+    first = {"data": [{"id": "a"}], "next_cursor": "abc"}
+    second = {"data": [{"id": "b"}], "next_cursor": None}
+
+    responses.add(
+        responses.GET,
+        endpoint,
+        json=first,
+        status=200,
+    )
+    responses.add(
+        responses.GET,
+        endpoint,
+        json=second,
+        match=[responses.matchers.query_param_matcher({"cursor": "abc"})],
+        status=200,
+    )
+
+    client = ClientBuilder(endpoint=endpoint)
+    client.with_pagination(
+        PaginationStrategy.CURSOR,
+        results_key="data",
+        next_cursor_key="next_cursor",
+    )
+
+    result = client.get_api_data()
+
+    assert result.metadata["pages"] == 2
+    assert result.metadata["last_cursor"] is None
+    assert [item["id"] for item in result.records] == ["a", "b"]
+
+
+def test_with_pagination_invalid_offset_limit_arguments():
+    """Invalid limit values should raise a ValueError."""
+
+    client = ClientBuilder(endpoint="https://api.example.com/resources")
+
+    with pytest.raises(ValueError):
+        client.with_pagination(PaginationStrategy.OFFSET_LIMIT, limit=0)
+
+
+def test_with_pagination_invalid_page_arguments():
+    """Page strategy validates the starting page value."""
+
+    client = ClientBuilder(endpoint="https://api.example.com/resources")
+
+    with pytest.raises(ValueError):
+        client.with_pagination(PaginationStrategy.PAGE, start_page=0)


### PR DESCRIPTION
## Summary
- add reusable pagination iterators and expose pagination strategy metadata on the client
- aggregate paginated responses into DataFetchResult and update documentation with pagination usage
- expand unit test coverage for pagination patterns and DataFetchResult handling

## Testing
- `poetry run pylint src/api_to_dataframe`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_690ba1452b88832b9e0912eece6a9778