### PR TITLE
feat: support configurable HTTP requests in client builder

### DIFF
--- a/src/api_to_dataframe/controller/client_builder.py
+++ b/src/api_to_dataframe/controller/client_builder.py
@@ -1,13 +1,15 @@
-from api_to_dataframe.models.retainer import retry_strategies, Strategies
+from typing import Any, Dict, Optional
+
 from api_to_dataframe.models.get_data import GetData
+from api_to_dataframe.models.retainer import Strategies, retry_strategies
 from api_to_dataframe.utils.logger import logger
 
 
-class ClientBuilder:
+class ClientBuilder:  # pylint: disable=too-many-instance-attributes
     def __init__(  # pylint: disable=too-many-positional-arguments,too-many-arguments
         self,
         endpoint: str,
-        headers: dict = None,
+        headers: Optional[Dict[str, str]] = None,
         retry_strategy: Strategies = Strategies.NO_RETRY_STRATEGY,
         retries: int = 3,
         initial_delay: int = 1,
@@ -57,6 +59,78 @@ class ClientBuilder:
         self.retries = retries
         self.delay = initial_delay
 
+        self._method: str = "GET"
+        self._params: Optional[Dict[str, Any]] = None
+        self._json_payload: Optional[Any] = None
+        self._data_payload: Optional[Any] = None
+        self._files_payload: Optional[Any] = None
+        self._auth: Optional[Any] = None
+        self._session: Optional[Any] = None
+
+    def with_method(self, method: str):
+        """Configure the HTTP method for the request."""
+
+        if not isinstance(method, str) or not method.strip():
+            error_msg = "method must be a non-empty string"
+            logger.error(error_msg)
+            raise ValueError(error_msg)
+
+        self._method = method.strip().upper()
+        return self
+
+    def with_params(self, params: Optional[Dict[str, Any]]):
+        """Configure query parameters to be sent with the request."""
+
+        if params is not None and not isinstance(params, dict):
+            error_msg = "params must be a dictionary or None"
+            logger.error(error_msg)
+            raise ValueError(error_msg)
+
+        self._params = params
+        return self
+
+    def with_payload(
+        self,
+        *,
+        json: Optional[Any] = None,
+        data: Optional[Any] = None,
+        files: Optional[Any] = None,
+    ):
+        """Configure payload content for the request body."""
+
+        self._json_payload = json
+        self._data_payload = data
+        self._files_payload = files
+        return self
+
+    def with_auth(self, auth: Optional[Any]):
+        """Configure authentication details for the request."""
+
+        self._auth = auth
+        return self
+
+    def with_session(self, session: Optional[Any]):
+        """Configure a custom session implementation for the request."""
+
+        if session is not None and not hasattr(session, "request"):
+            error_msg = "session must provide a request method"
+            logger.error(error_msg)
+            raise ValueError(error_msg)
+
+        self._session = session
+        return self
+
+    def with_headers(self, headers: Optional[Dict[str, str]]):
+        """Override headers after initialization while keeping fluent style."""
+
+        if headers is not None and not isinstance(headers, dict):
+            error_msg = "headers must be a dictionary or None"
+            logger.error(error_msg)
+            raise ValueError(error_msg)
+
+        self.headers = headers or {}
+        return self
+
     @retry_strategies
     def get_api_data(self):
         """
@@ -73,6 +147,13 @@ class ClientBuilder:
             endpoint=self.endpoint,
             headers=self.headers,
             connection_timeout=self.connection_timeout,
+            method=self._method,
+            params=self._params,
+            json=self._json_payload,
+            data=self._data_payload,
+            files=self._files_payload,
+            auth=self._auth,
+            session=self._session,
         )
 
         return response.json()

--- a/src/api_to_dataframe/models/get_data.py
+++ b/src/api_to_dataframe/models/get_data.py
@@ -1,21 +1,53 @@
-import requests
+from typing import Any, Dict, Optional
+
 import pandas as pd
+import requests
+
 from api_to_dataframe.utils.logger import logger
 
 
 class GetData:
     @staticmethod
-    def get_response(endpoint: str, headers: dict, connection_timeout: int):
-        # Make the request
-        response = requests.get(endpoint, timeout=connection_timeout, headers=headers)
+    def get_response(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+        endpoint: str,
+        headers: Optional[Dict[str, str]],
+        connection_timeout: int,
+        method: str = "GET",
+        params: Optional[Dict[str, Any]] = None,
+        json: Optional[Any] = None,
+        data: Optional[Any] = None,
+        files: Optional[Any] = None,
+        auth: Optional[Any] = None,
+        session: Optional[requests.Session] = None,
+    ):
+        """Execute an HTTP request and return the raw response."""
 
-        # Attempt to raise for status to catch errors
+        if not isinstance(method, str) or not method.strip():
+            error_msg = "method must be a non-empty string"
+            logger.error(error_msg)
+            raise ValueError(error_msg)
+
+        request_callable = session.request if session else requests.request
+
+        response = request_callable(
+            method=method.upper(),
+            url=endpoint,
+            timeout=connection_timeout,
+            headers=headers,
+            params=params,
+            json=json,
+            data=data,
+            files=files,
+            auth=auth,
+        )
+
         response.raise_for_status()
 
         return response
 
     @staticmethod
     def to_dataframe(response):
+        """Convert an API response payload into a pandas DataFrame."""
         df = pd.DataFrame(response)
 
         # Check if DataFrame is empty

--- a/tests/test_controller_client_builder.py
+++ b/tests/test_controller_client_builder.py
@@ -7,21 +7,15 @@ from api_to_dataframe import ClientBuilder, RetryStrategies
 
 @pytest.fixture()
 def client_setup():
+    """Create a default ClientBuilder instance for tests."""
     new_client = ClientBuilder(
         endpoint="https://economia.awesomeapi.com.br/last/USD-BRL"
     )
     return new_client
 
 
-@pytest.fixture()
-def response_setup():
-    new_client = ClientBuilder(
-        endpoint="https://economia.awesomeapi.com.br/last/USD-BRL"
-    )
-    return new_client.get_api_data()
-
-
 def test_constructor_raises():
+    """Ensure constructor validations raise errors for invalid inputs."""
     with pytest.raises(ValueError):
         ClientBuilder(endpoint="")
 
@@ -59,13 +53,14 @@ def test_constructor_raises():
 
 
 def test_constructor_with_param(client_setup):  # pylint: disable=redefined-outer-name
+    """Ensure constructor stores the provided endpoint value."""
     expected_result = "https://economia.awesomeapi.com.br/last/USD-BRL"
     new_client = client_setup
     assert new_client.endpoint == expected_result
 
 
 def test_constructor_with_headers():
-    """Test ClientBuilder with custom headers"""
+    """Test ClientBuilder with custom headers."""
     custom_headers = {"Authorization": "Bearer token123", "Content-Type": "application/json"}
     client = ClientBuilder(
         endpoint="https://economia.awesomeapi.com.br/last/USD-BRL",
@@ -75,7 +70,7 @@ def test_constructor_with_headers():
 
 
 def test_constructor_with_retry_strategy():
-    """Test ClientBuilder with different retry strategies"""
+    """Test ClientBuilder with different retry strategies."""
     client = ClientBuilder(
         endpoint="https://economia.awesomeapi.com.br/last/USD-BRL",
         retry_strategy=RetryStrategies.LINEAR_RETRY_STRATEGY,
@@ -87,20 +82,34 @@ def test_constructor_with_retry_strategy():
     assert client.delay == 2
 
 
+@responses.activate
 def test_response_to_json(client_setup):  # pylint: disable=redefined-outer-name
+    """Ensure API responses are converted to JSON objects."""
     new_client = client_setup
+    expected_response = {"key": "value"}
+
+    responses.add(
+        responses.GET,
+        new_client.endpoint,
+        json=expected_response,
+        status=200,
+    )
+
     response = new_client.get_api_data()  # pylint: disable=protected-access
     assert isinstance(response, dict)
+    assert response == expected_response
 
 
-def test_to_dataframe(response_setup):  # pylint: disable=redefined-outer-name
-    df = ClientBuilder.api_to_dataframe(response_setup)
+def test_to_dataframe():
+    """Ensure responses can be converted into DataFrames."""
+    sample_response = [{"currency": "USD", "bid": "5.0"}]
+    df = ClientBuilder.api_to_dataframe(sample_response)
     assert isinstance(df, pd.DataFrame)
 
 
 @responses.activate
 def test_get_api_data_with_mocked_response():
-    """Test get_api_data with mocked API response"""
+    """Test get_api_data with mocked API response."""
     endpoint = "https://api.test.com/data"
     expected_data = {"key": "value", "nested": {"id": 123}}
 
@@ -118,3 +127,77 @@ def test_get_api_data_with_mocked_response():
     assert response == expected_data
     assert len(responses.calls) == 1
     assert responses.calls[0].request.url == endpoint
+
+
+def test_with_method_configures_request_method():
+    """Ensure with_method configures the HTTP method for requests."""
+
+    client = ClientBuilder(endpoint="https://api.test.com").with_method("post")
+    assert client._method == "POST"  # pylint: disable=protected-access
+
+
+def test_with_params_validates_input_type():
+    """Ensure with_params only accepts dictionaries."""
+
+    client = ClientBuilder(endpoint="https://api.test.com")
+    assert client.with_params({"page": 1}) is client
+
+    with pytest.raises(ValueError):
+        client.with_params([("page", 1)])
+
+
+def test_with_payload_replaces_existing_payload():
+    """Ensure with_payload stores json, data and file payloads."""
+
+    client = ClientBuilder(endpoint="https://api.test.com")
+    client.with_payload(json={"name": "Jane"}, data=None)
+
+    assert client._json_payload == {"name": "Jane"}  # pylint: disable=protected-access
+    assert client._data_payload is None  # pylint: disable=protected-access
+
+
+def test_with_session_validates_interface():
+    """Ensure with_session requires an object exposing request."""
+
+    client = ClientBuilder(endpoint="https://api.test.com")
+
+    class DummySession:
+        """Expose a request method to mimic a real session."""
+
+        def request(self, **kwargs):  # pragma: no cover - dummy implementation
+            return kwargs
+
+    session = DummySession()
+    assert client.with_session(session) is client
+
+    with pytest.raises(ValueError):
+        client.with_session(object())
+
+
+@responses.activate
+def test_fluent_configuration_executes_request():
+    """Ensure fluent configuration works when executing requests."""
+
+    endpoint = "https://api.test.com/submit"
+    payload = {"name": "John"}
+    expected_response = {"status": "created"}
+
+    responses.add(
+        responses.POST,
+        endpoint,
+        json=expected_response,
+        status=201,
+    )
+
+    client = (
+        ClientBuilder(endpoint=endpoint)
+        .with_method("POST")
+        .with_payload(json=payload)
+        .with_params({"verbose": "true"})
+    )
+
+    response = client.get_api_data()
+
+    assert response == expected_response
+    assert responses.calls[0].request.method == "POST"
+    assert "verbose=true" in responses.calls[0].request.url

--- a/tests/test_models_get_data.py
+++ b/tests/test_models_get_data.py
@@ -1,22 +1,29 @@
+import json
+from typing import Any, Dict
+
+import pandas as pd
 import pytest
 import requests
 import responses
-import pandas as pd
-import json
+from responses import matchers
 
-from api_to_dataframe.models.get_data import GetData
 from api_to_dataframe.controller.client_builder import ClientBuilder
+from api_to_dataframe.models.get_data import GetData
 
 
-def test_to_dataframe():
+def test_to_dataframe_empty_payload():
+    """Ensure converting an empty payload raises a ValueError."""
+
     with pytest.raises(ValueError):
         GetData.to_dataframe("")
 
 
 @responses.activate
-def test_to_emp_dataframe():
+def test_to_dataframe_from_empty_response():
+    """Validate that an empty response from the API raises a ValueError."""
+
     endpoint = "https://api.exemplo.com"
-    expected_response = {}
+    expected_response: Dict[str, Any] = {}
 
     responses.add(responses.GET, endpoint, json=expected_response, status=200)
 
@@ -27,11 +34,9 @@ def test_to_emp_dataframe():
         GetData.to_dataframe(response)
 
 
-@responses.activate
 def test_valid_dataframe_conversion():
-    """Test successful conversion of valid data to DataFrame"""
-    # A estrutura do dict afeta como o pandas cria o DataFrame
-    # Os dados precisam estar em uma lista para serem convertidos em linhas
+    """Test successful conversion of valid data to a DataFrame."""
+
     valid_data = [{"id": 1, "name": "Test"}, {"id": 2, "name": "Test2"}]
     df = GetData.to_dataframe(valid_data)
 
@@ -43,16 +48,14 @@ def test_valid_dataframe_conversion():
     assert df.iloc[1]["name"] == "Test2"
 
 
-@responses.activate
 def test_nested_data_conversion():
-    """Test conversion of nested data structures"""
-    # Lista de dicionários é mais adequado para converter em DataFrame
+    """Test conversion of nested data structures."""
+
     nested_data = [
         {"user": {"id": 1, "profile": {"name": "User1"}}},
-        {"user": {"id": 2, "profile": {"name": "User2"}}}
+        {"user": {"id": 2, "profile": {"name": "User2"}}},
     ]
 
-    # Convert to string and back to dict to simulate JSON response
     json_str = json.dumps(nested_data)
     response_list = json.loads(json_str)
 
@@ -60,12 +63,33 @@ def test_nested_data_conversion():
     assert isinstance(df, pd.DataFrame)
     assert not df.empty
     assert len(df) == 2
-    # Verificar estrutura das colunas
     assert "user" in df.columns
+
+
+@pytest.mark.parametrize("method", ["GET", "POST", "PUT", "PATCH", "DELETE"])
+@responses.activate
+def test_http_methods_are_supported(method):
+    """Ensure GetData can send requests using multiple HTTP methods."""
+
+    endpoint = f"https://api.exemplo.com/{method.lower()}"
+    expected_response = {"method": method}
+
+    responses.add(getattr(responses, method), endpoint, json=expected_response, status=200)
+
+    response = GetData.get_response(
+        endpoint=endpoint,
+        headers={},
+        connection_timeout=10,
+        method=method,
+    )
+
+    assert response.json() == expected_response
 
 
 @responses.activate
 def test_http_error():
+    """Ensure HTTP errors raise the corresponding exception."""
+
     endpoint = "https://api.exemplo.com"
     expected_response = {}
 
@@ -77,7 +101,8 @@ def test_http_error():
 
 @responses.activate
 def test_http_error_with_custom_message():
-    """Test HTTP error with custom error message in response"""
+    """Test HTTP error handling when a custom message is returned."""
+
     endpoint = "https://api.exemplo.com/error"
     error_response = {"error": "Bad Request", "message": "Invalid parameters"}
 
@@ -85,15 +110,17 @@ def test_http_error_with_custom_message():
         responses.GET,
         endpoint,
         json=error_response,
-        status=400
+        status=400,
     )
 
     with pytest.raises(requests.exceptions.HTTPError):
-        response = GetData.get_response(endpoint=endpoint, headers={}, connection_timeout=10)
+        GetData.get_response(endpoint=endpoint, headers={}, connection_timeout=10)
 
 
 @responses.activate
 def test_timeout_error():
+    """Ensure timeout errors from requests are propagated."""
+
     endpoint = "https://api.exemplo.com"
 
     responses.add(responses.GET, endpoint, body=requests.exceptions.Timeout())
@@ -104,8 +131,9 @@ def test_timeout_error():
 
 @responses.activate
 def test_request_exception():
-    endpoint = "https://api.exemplo.com"
+    """Ensure generic request exceptions are propagated."""
 
+    endpoint = "https://api.exemplo.com"
     expected_response = {}
 
     responses.add(responses.GET, endpoint, json=expected_response, status=500)
@@ -116,13 +144,14 @@ def test_request_exception():
 
 @responses.activate
 def test_headers_passed_correctly():
-    """Test that headers are correctly passed to the request"""
+    """Verify that custom headers are forwarded to the HTTP request."""
+
     endpoint = "https://api.exemplo.com/headers"
     expected_response = {"success": True}
     custom_headers = {
         "Authorization": "Bearer test-token",
         "X-Custom-Header": "test-value",
-        "Content-Type": "application/json"
+        "Content-Type": "application/json",
     }
 
     def match_headers(request):
@@ -135,14 +164,160 @@ def test_headers_passed_correctly():
         responses.GET,
         endpoint,
         callback=match_headers,
-        content_type="application/json"
+        content_type="application/json",
     )
 
     response = GetData.get_response(
         endpoint=endpoint,
         headers=custom_headers,
-        connection_timeout=10
+        connection_timeout=10,
     )
 
     assert response.status_code == 200
     assert response.json() == expected_response
+
+
+@responses.activate
+def test_query_params_are_forwarded():
+    """Verify that query parameters are forwarded to the request."""
+
+    endpoint = "https://api.exemplo.com/query"
+    params = {"page": "1", "size": "20"}
+    expected_response = {"success": True}
+
+    responses.add(
+        responses.GET,
+        endpoint,
+        json=expected_response,
+        match=[matchers.query_param_matcher(params)],
+        status=200,
+    )
+
+    response = GetData.get_response(
+        endpoint=endpoint,
+        headers={},
+        connection_timeout=10,
+        params=params,
+    )
+
+    assert response.json() == expected_response
+
+
+@responses.activate
+def test_json_payload_is_sent():
+    """Ensure JSON payloads are transmitted for request bodies."""
+
+    endpoint = "https://api.exemplo.com/json"
+    payload = {"name": "Jane"}
+    expected_response = {"status": "ok"}
+
+    def validate_json_payload(request):
+        body_raw = request.body.decode("utf-8") if isinstance(request.body, bytes) else request.body
+        body = json.loads(body_raw) if body_raw else {}
+        if body != payload:
+            return (400, {}, json.dumps({"error": "invalid"}))
+        return (200, {}, json.dumps(expected_response))
+
+    responses.add_callback(
+        responses.POST,
+        endpoint,
+        callback=validate_json_payload,
+        content_type="application/json",
+    )
+
+    response = GetData.get_response(
+        endpoint=endpoint,
+        headers={"Content-Type": "application/json"},
+        connection_timeout=10,
+        method="POST",
+        json=payload,
+    )
+
+    assert response.json() == expected_response
+
+
+@responses.activate
+def test_form_payload_is_sent():
+    """Ensure form payloads are transmitted correctly."""
+
+    endpoint = "https://api.exemplo.com/form"
+    payload = {"field": "value"}
+    expected_response = {"status": "ok"}
+
+    def validate_form_payload(request):
+        body = (
+            request.body.decode("utf-8")
+            if isinstance(request.body, bytes)
+            else (request.body or "")
+        )
+        if body != "field=value":
+            return (400, {}, json.dumps({"error": "invalid"}))
+        return (200, {}, json.dumps(expected_response))
+
+    responses.add_callback(
+        responses.POST,
+        endpoint,
+        callback=validate_form_payload,
+        content_type="application/json",
+    )
+
+    response = GetData.get_response(
+        endpoint=endpoint,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        connection_timeout=10,
+        method="POST",
+        data=payload,
+    )
+
+    assert response.json() == expected_response
+
+
+def test_custom_session_is_used():
+    """Ensure a custom session object is used for the request."""
+
+    class DummySession:
+        """Dummy session collecting the last request call."""
+
+        def __init__(self):
+            self.called_with = None
+
+        def request(self, **kwargs):
+            self.called_with = kwargs
+
+            class DummyResponse:
+                """Simple response mimicking the requests interface."""
+
+                def __init__(self):
+                    self._json = {"status": "dummy"}
+
+                def raise_for_status(self):
+                    return None
+
+                def json(self):
+                    return self._json
+
+            return DummyResponse()
+
+    session = DummySession()
+
+    response = GetData.get_response(
+        endpoint="https://api.exemplo.com/session",
+        headers={},
+        connection_timeout=10,
+        session=session,
+    )
+
+    assert session.called_with["method"] == "GET"
+    assert response.json()["status"] == "dummy"
+
+
+def test_invalid_method_raises_value_error():
+    """Ensure invalid HTTP method values raise ValueError."""
+
+    with pytest.raises(ValueError):
+        GetData.get_response(
+            endpoint="http://example.com",
+            headers={},
+            connection_timeout=10,
+            method="",
+        )


### PR DESCRIPTION
## Summary
- extend GetData to support configurable HTTP methods, payloads, authentication, and custom sessions
- expose fluent configuration methods on ClientBuilder for method, params, payload, session, and headers
- expand test coverage for HTTP method handling, payload forwarding, and ClientBuilder fluent API behaviours

## Testing
- PYTHONPATH=src poetry run pylint src/api_to_dataframe/models/get_data.py src/api_to_dataframe/controller/client_builder.py tests/test_models_get_data.py tests/test_controller_client_builder.py
- poetry run pytest -v

------
https://chatgpt.com/codex/tasks/task_e_690ba13c94c0832b82cef4161abdd7d8