### PR TITLE
ci: use reusable tests-python-poetry workflow

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -1,46 +1,16 @@
-name: Tests and Pre-build
+name: Tests
 
 on:
   pull_request:
     branches:
       - main
-
-  # For manual triggers
   workflow_dispatch:
 
 jobs:
   test:
-    if: github.actor != 'actions[bot]'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          ref: ${{ github.head_ref }}
-
-      - name: Set up Python 3.10
-        uses: actions/setup-python@v2
-        with:
-          python-version: '3.10'
-
-      - name: Setup tests
-        run: |
-          pip install --upgrade pip
-          pip install poetry
-          poetry config virtualenvs.create false
-          poetry install
-
-      - name: Run tests & CodeCov
-        run: |
-          coverage run -m pytest
-          coverage report
-          coverage xml
-
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v4.0.1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage.xml
-
-    environment:
-      name: Development
-      url: https://test.pypi.org/project/api-to-dataframe/
+    uses: ivanildobarauna/github-workflows/.github/workflows/tests-python-poetry.yml@v1
+    with:
+      python-versions: '["3.10"]'
+      environment: Development
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary
- Replaces the previous CI YAML with a thin caller of `ivanildobarauna/github-workflows/.github/workflows/tests-python-poetry.yml@v1`.
- Behavior preserved: Python 3.10, Codecov upload, runs on PRs to `main`, `Development` environment.

## Test plan
- [ ] CI run on this PR is green
- [ ] Codecov upload appears in the run logs